### PR TITLE
[Bug] Fix Home Page Loading Error (SC-184721)

### DIFF
--- a/src/components/EventDetails/EventDetails.tsx
+++ b/src/components/EventDetails/EventDetails.tsx
@@ -1,21 +1,14 @@
-import { match } from "ts-pattern";
-import get from "lodash/get";
+import { CalendarLogo, Container, MdContainer, OverflowText, Property } from "../common";
+import { EVENT_FORMAT } from "../../constants";
 import { faCheck, faX, faQuestion } from "@fortawesome/free-solid-svg-icons";
+import { format } from "../../utils/date";
+import { linkRenderer } from "../../utils";
+import { match } from "ts-pattern";
 import { P5, Stack, TagCircleIcon } from "@deskpro/deskpro-ui";
 import { Title } from "@deskpro/app-sdk";
-import { format } from "../../utils/date";
-import { EVENT_FORMAT } from "../../constants";
-import { linkRenderer } from "../../utils";
-import {
-  Property,
-  Container,
-  MdContainer,
-  OverflowText,
-  CalendarLogo,
-} from "../common";
-import type { FC } from "react";
 import type { AnyIcon } from "@deskpro/deskpro-ui";
 import type { Event, CalendarItem } from "../../services/google/types";
+import type { FC } from "react";
 
 type Props = {
   event: Event,
@@ -23,33 +16,33 @@ type Props = {
 };
 
 const EventDetails: FC<Props> = ({ event, calendar }) => {
-  const isAttendees = Array.isArray(get(event, ["attendees"])) && event.attendees.length > 0;
+  const isAttendees = Array.isArray(event?.attendees) && event.attendees.length > 0;
 
   return (
     <Container>
       <Title
-        title={get(event, ["summary"], "-")}
-        link={get(event, ["htmlLink"], "")}
+        title={event?.summary ?? "Untitled Event"}
+        link={event?.htmlLink ?? "#"}
         icon={<CalendarLogo />}
       />
 
-      <Property label="Calendar" text={get(calendar, ["summary"], "-")} />
+      <Property label="Calendar" text={calendar?.summary ?? "-"} />
 
       <Property
         label="Description"
         text={(
-          <P5 dangerouslySetInnerHTML={{ __html: get(event, ["description"], "-") }} />
+          <P5 dangerouslySetInnerHTML={{ __html: event?.description ?? "-" }} />
         )}
       />
 
       <Property
         label="Start date"
-        text={format(event.start.dateTime?? event.start.date, EVENT_FORMAT)}
+        text={format(event?.start?.dateTime ?? event?.start?.date, EVENT_FORMAT)}
       />
 
       <Property
         label="End date"
-        text={format(event.end.dateTime?? event.end.date, EVENT_FORMAT)}
+        text={format(event?.end?.dateTime ?? event?.end?.date, EVENT_FORMAT)}
       />
 
       <Property
@@ -72,14 +65,14 @@ const EventDetails: FC<Props> = ({ event, calendar }) => {
         )}
       />
 
-      <Property label="Creator" text={get(event, ["creator", "email"], "-")} />
+      <Property label="Creator" text={event?.creator?.email ?? "-"} />
 
       <Property
         label="Location"
         text={(
           <MdContainer
             dangerouslySetInnerHTML={{
-              __html: linkRenderer(get(event, ["location"], "-")),
+              __html: linkRenderer(event?.location ?? "-"),
             }}
           />
         )}

--- a/src/components/EventDetails/EventDetails.tsx
+++ b/src/components/EventDetails/EventDetails.tsx
@@ -44,12 +44,12 @@ const EventDetails: FC<Props> = ({ event, calendar }) => {
 
       <Property
         label="Start date"
-        text={format(get(event, ["start", "dateTime"]), EVENT_FORMAT)}
+        text={format(event.start.dateTime?? event.start.date, EVENT_FORMAT)}
       />
 
       <Property
         label="End date"
-        text={format(get(event, ["end", "dateTime"]), EVENT_FORMAT)}
+        text={format(event.end.dateTime?? event.end.date, EVENT_FORMAT)}
       />
 
       <Property

--- a/src/components/Home/Event.tsx
+++ b/src/components/Home/Event.tsx
@@ -30,7 +30,7 @@ const Event: FC<Props> = ({
     <>
       <Title
         as={H3}
-        title={<Link href="#" onClick={onClick}>{summary}</Link>}
+        title={<Link href="#" onClick={onClick}>{summary ?? "Untitled event"}</Link>}
         link={htmlLink}
         icon={<CalendarLogo />}
         marginBottom={7}

--- a/src/components/Home/Event.tsx
+++ b/src/components/Home/Event.tsx
@@ -37,7 +37,7 @@ const Event: FC<Props> = ({
       />
       <TwoProperties
         leftLabel="Time"
-        leftText={`${format(start.dateTime, TIME_FORMAT)} - ${format(end.dateTime, TIME_FORMAT)}`}
+        leftText={formatEventTime(start, end)}
         rightLabel="Calendar"
         rightText={<OverflowText as={P5}>{calendarSummary}</OverflowText>}
         marginBottom={20}
@@ -47,3 +47,23 @@ const Event: FC<Props> = ({
 };
 
 export { Event };
+
+function formatEventTime(start?: EventType["start"], end?: EventType["end"]) {
+  let eventTimeString;
+
+  if (start?.dateTime && end?.dateTime) {
+    // If both start and end dateTime are present
+    eventTimeString = `${format(start.dateTime, TIME_FORMAT)} - ${format(end.dateTime, TIME_FORMAT)}`;
+  } else if (start?.dateTime) {
+    // If only start dateTime is present
+    eventTimeString = format(start.dateTime, TIME_FORMAT);
+  } else if (end?.dateTime) {
+    // If only end dateTime is present
+    eventTimeString = format(end.dateTime, TIME_FORMAT);
+  } else {
+    // If neither dateTime is present, show as all-day event
+    eventTimeString = "All day";
+  }
+
+  return eventTimeString
+}

--- a/src/components/Home/Events.tsx
+++ b/src/components/Home/Events.tsx
@@ -1,16 +1,14 @@
-import { useMemo, Fragment } from "react";
-import size from "lodash/size";
-import map from "lodash/map";
-import { P3, H1 } from "@deskpro/deskpro-ui";
-import { HorizontalDivider } from "@deskpro/app-sdk";
-import { getMapFilteredEventsByDay } from "../../utils";
-import { DAY_FORMAT } from "../../constants";
-import { format } from "../../utils/date";
 import { Container } from "../common";
+import { DAY_FORMAT } from "../../constants";
 import { Event } from "./Event";
+import { format } from "../../utils/date";
+import { getMapFilteredEventsByDay } from "../../utils";
+import { HorizontalDivider } from "@deskpro/app-sdk";
 import { LoadNextWeek } from "./LoadNextWeek";
-import type { FC } from "react";
+import { P3, H1 } from "@deskpro/deskpro-ui";
+import { useMemo, Fragment } from "react";
 import type { EventType } from "../../types";
+import type { FC } from "react";
 
 type Props = {
   events: EventType[],
@@ -21,7 +19,7 @@ type Props = {
 const Events: FC<Props> = ({ events, onLoadNextWeek, onNavigateToEvent }) => {
   const mapFilteredEvents = useMemo(() => getMapFilteredEventsByDay(events), [events]);
 
-  return (size(events) === 0)
+  return (events.length === 0)
     ? (
       <Container>
         <P3>No events found in calendar(s)</P3>
@@ -29,16 +27,20 @@ const Events: FC<Props> = ({ events, onLoadNextWeek, onNavigateToEvent }) => {
     )
     : (
       <>
-        {map(mapFilteredEvents, (value, day) => (
+        {/* Render the events grouped by days */}
+        {Object.entries(mapFilteredEvents).map(([day, value]) => (
           <Fragment key={day}>
             <Container>
               <H1 style={{ marginBottom: 14 }}>{format(day, DAY_FORMAT)}</H1>
-              {value.map((event) => <Event key={event.id} {...event} onNavigateToEvent={onNavigateToEvent} />)}
+              {value.map((event) => (
+                <Event key={event.id} {...event} onNavigateToEvent={onNavigateToEvent} />
+              ))}
             </Container>
-            <HorizontalDivider style={{ marginBottom: 10 }}/>
+            <HorizontalDivider style={{ marginBottom: 10 }} />
           </Fragment>
         ))}
-        <LoadNextWeek onLoadNextWeek={onLoadNextWeek}/>
+
+        <LoadNextWeek onLoadNextWeek={onLoadNextWeek} />
       </>
     )
 };

--- a/src/pages/CreateEventPage/CreateEventPage.tsx
+++ b/src/pages/CreateEventPage/CreateEventPage.tsx
@@ -49,7 +49,7 @@ const CreateEventPage: FC = () => {
     registerElement("refresh", { type: "refresh_button" });
     registerElement("home", {
       type: "home_button",
-      payload: { type: "changePage", path: -1 },
+      payload: { type: "changePage", path: "/home" },
     });
   });
 

--- a/src/pages/EventDetailsPage/EventDetailsPage.tsx
+++ b/src/pages/EventDetailsPage/EventDetailsPage.tsx
@@ -20,7 +20,7 @@ const EventDetailsPage: FC = () => {
     registerElement("refresh", { type: "refresh_button" });
     registerElement("home", {
       type: "home_button",
-      payload: { type: "changePage", path: -1 },
+      payload: { type: "changePage", path: "/home" },
     });
   });
 

--- a/src/utils/getFilteredDaysFromEvents.ts
+++ b/src/utils/getFilteredDaysFromEvents.ts
@@ -1,16 +1,21 @@
-import isEmpty from "lodash/isEmpty";
 import startOfDay from "date-fns/startOfDay";
 import type { EventType, DateTime } from "../types";
 
 const getFilteredDaysFromEvents = (events?: EventType[]): DateTime[] => {
   const daysList: DateTime[] = [];
 
-  if (!Array.isArray(events) || isEmpty(events)) {
+  if (!Array.isArray(events) || events.length <= 0) {
     return daysList;
   }
 
   events.forEach((event) => {
-    const { start: { dateTime }} = event;
+    const { start } = event;
+
+    const dateTime = start.dateTime ?? start.date
+
+    if (!dateTime) {
+      return;
+    }
     const startDate = startOfDay(new Date(dateTime)).toISOString();
 
     if (!daysList.includes(startDate)) {

--- a/src/utils/getMapFilteredEventsByDay.ts
+++ b/src/utils/getMapFilteredEventsByDay.ts
@@ -1,19 +1,24 @@
-import isEmpty from "lodash/isEmpty";
-import startOfDay from "date-fns/startOfDay";
 import { getFilteredDaysFromEvents } from "./getFilteredDaysFromEvents";
+import startOfDay from "date-fns/startOfDay";
 import type { EventType, DateTime } from "../types";
 
 const getMapFilteredEventsByDay = (
   events?: EventType[],
 ): Record<DateTime, EventType[]> => {
-  if (!Array.isArray(events) || isEmpty(events)) {
+
+  if (!Array.isArray(events) || events.length <= 0) {
     return {};
   }
-
   const daysList = getFilteredDaysFromEvents(events);
 
   return daysList.reduce<Record<DateTime, EventType[]>>((acc, day) => {
-    acc[day] = events.filter((event) => startOfDay(new Date(event.start.dateTime)).toISOString() === day);
+
+    acc[day] = events.filter((event) => {
+
+      const dateTime = event.start.dateTime ?? event.start.date
+
+      return startOfDay(new Date(dateTime)).toISOString() === day
+    });
     // sort by date
     acc[day].sort((a, b) => new Date(a.start.dateTime).getTime() - new Date(b.start.dateTime).getTime());
     return acc;


### PR DESCRIPTION
## Description
This PR addresses the following issues:
- Fixed a crash that occurred when users selected a calendar containing an event without start/end `dateTime` (All-day events).
- Resolved an issue where private and unnamed events displayed without a title,
- Fixed a bug where clicking the home button sometimes redirected users to the login page.

## Evidence

https://github.com/user-attachments/assets/d12f494e-06a3-466b-9749-42529beb429c

