### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -56,7 +56,15 @@
       {
         "url": "https://oauth2.googleapis.com/.*",
         "methods": ["GET", "POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "client_id": {
+            "querystring": ["client_id"]
+          },
+          "client_secret": {
+            "querystring": ["client_secret"]
+          }
+        }
       }
     ]
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,7 +19,7 @@ export const ACCESS_TOKEN = `[user[${ACCESS_TOKEN_PATH}]]`;
 export const placeholders = {
   client_id: "__client_id__",
   client_secret: "__client_secret__",
-};
+} as const;
 
 /** Google */
 export const BASE_URL = "https://www.googleapis.com/calendar/v3";


### PR DESCRIPTION
This pull request introduces enhancements to how client credentials are handled for Google OAuth requests and makes a minor improvement to the constants definition for better type safety.

**Credential Injection Improvements:**

* Updated the `manifest.json` to support automatic injection of `client_id` and `client_secret` into the query string for requests to `https://oauth2.googleapis.com/.*`, improving security and configuration flexibility.

**Type Safety Enhancement:**

* Changed the `placeholders` object in `src/constants.ts` to use `as const`, ensuring stricter type safety for its values.

## Summary by Sourcery

Improve app proxy security by scoping credential injection for Google OAuth requests and strengthen type safety for token placeholders

New Features:
- Add settingsInjection in manifest.json to inject client_id and client_secret into query parameters for https://oauth2.googleapis.com endpoints

Enhancements:
- Mark placeholders object as const in constants.ts for stricter type safety